### PR TITLE
#3 nginx.confにalp集計用の設定を追加

### DIFF
--- a/files/app/nginx.conf
+++ b/files/app/nginx.conf
@@ -1,3 +1,21 @@
+log_format ltsv "time:$time_local"
+                "\thost:$remote_addr"
+                "\tforwardedfor:$http_x_forwarded_for"
+                "\treq:$request"
+                "\tstatus:$status"
+                "\tmethod:$request_method"
+                "\turi:$request_uri"
+                "\tsize:$body_bytes_sent"
+                "\treferer:$http_referer"
+                "\tua:$http_user_agent"
+                "\treqtime:$request_time"
+                "\tcache:$upstream_http_x_cache"
+                "\truntime:$upstream_http_x_runtime"
+                "\apptime:$upstream_response_time"
+                "\tvhost:$host";
+
+access_log /var/log/nginx/access.log ltsv;
+
 server {
         listen 80 default_server;
         listen [::]:80 default_server;


### PR DESCRIPTION
## 概要

`alp`を利用するためのnginx設定ファイルの変更。

### 対象となるアクセスログファイル

- `/var/log/nginx/access.log`

### alp実行方法

```
alp ltsv --file=/var/log/nginx/access.log -r --sort=max
```

### 補足

nginx.confをコピー後、以下のコマンドを実行すること

#### 1. 既存アクセスログのクリア

```
sudo echo -n "" > /var/log/nginx/access.log
```

#### 2. nginxプロセスの再起動

```
sudo systemctl restart nginx
```
